### PR TITLE
Fix potential crash in get_next_char( )

### DIFF
--- a/font.lua
+++ b/font.lua
@@ -59,7 +59,7 @@ local function get_next_char(text, pos)
 	end
 
 	-- 2 bytes char (little endian)
-	if msb >= 0xC2 then
+	if msb >= 0xC2 and text:byte(pos + 1) ~= nil then
 		return (msb - 0xC2) * 0x40 + text:byte(pos + 1),
 		       pos + 2
 	end


### PR DESCRIPTION
This fixes a game-crashing bug which occurs on some strings with variable length characters.

Test case: ```digiline_send("1", "@ł€¶ŧ←↓→ø");```
